### PR TITLE
Updated to Selenium Manager and added enrolment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,6 @@ Starting a large group of services in a profile can overload the cpu of a machin
 If this happens use one, or a combination of the following arguments: `--delay-seconds 5` to include a delay of 5
 seconds between sm2 starting each service and `--workers 1` to force sm2 to only start one service at a time.
 
-### Docker Selenium Grid
-
-Confirm that [docker-selenium-grid](https://github.com/hmrc/docker-selenium-grid) is up-to-date and follow the provided [instructions](https://github.com/hmrc/docker-selenium-grid/blob/main/README.md).
-
-
-### Test inspection and debugging
-
-Connect to port `7900` on the Grid browser's local IP address (see `localhost:4444/ui` to view each browser's IP) to 
-inspect and debug test execution in a noVNC window.
-
-
 ## Tests
 
 Run tests as follows:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     "ch.qos.logback"       % "logback-classic" % "1.5.1"         % Test,
     "com.vladsch.flexmark" % "flexmark-all"    % "0.64.8"        % Test,
     "org.scalatest"       %% "scalatest"       % "3.2.18"        % Test,
-    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.21.0"        % Test,
+    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.29.0"        % Test,
     "uk.gov.hmrc"         %% "domain"          % "8.3.0-play-28" % Test
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.24.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.26.0")

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -27,6 +27,12 @@ local {
       productionRoute = "/manage-your-crs-and-fatca-financial-institutions"
     }
   }
+
+  enrolment {
+    key = "HMRC-FATCA-ORG"
+    identifier = "FATCAID"
+    individualId = "XAFATCA0009234567"
+  }
 }
 
 dev {

--- a/src/test/scala/uk/gov/hmrc/test/ui/conf/EnrolmentConfig.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/conf/EnrolmentConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.test.ui.driver
+package uk.gov.hmrc.test.ui.conf
 
-import org.openqa.selenium.WebDriver
-import uk.gov.hmrc.selenium.webdriver.Driver
+case class EnrolmentConfig(
+  individual: Enrolment
+)
 
-trait BrowserDriver {
-
-  implicit def driver: WebDriver = Driver.instance
-
-}
+case class Enrolment(
+  key: String,
+  identifier: String,
+  value: String
+)

--- a/src/test/scala/uk/gov/hmrc/test/ui/conf/TestConfiguration.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/conf/TestConfiguration.scala
@@ -24,6 +24,15 @@ object TestConfiguration {
   val defaultConfig: Config = config.getConfig("local")
   val envConfig: Config     = config.getConfig(env).withFallback(defaultConfig)
 
+  val enrolmentConfig: EnrolmentConfig = {
+    val key        = envConfig.getString("enrolment.key")
+    val identifier = envConfig.getString("enrolment.identifier")
+
+    EnrolmentConfig(
+      individual = Enrolment(key, identifier, envConfig.getString("enrolment.individualId"))
+    )
+  }
+
   def url(service: String): String = {
     val host = env match {
       case "local" => s"$environmentHost:${servicePort(service)}"

--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/AuthLoginPage.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/AuthLoginPage.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.test.ui.pages
 
 import org.openqa.selenium.By
-import uk.gov.hmrc.test.ui.conf.TestConfiguration
+import uk.gov.hmrc.test.ui.conf.{Enrolment, TestConfiguration}
 
 object AuthLoginPage extends BasePage {
   override val pageUrl: String = TestConfiguration.url("auth-login-stub") + "/gg-sign-in"
@@ -27,6 +27,11 @@ object AuthLoginPage extends BasePage {
   private val redirectionUrlById: By = By.id("redirectionUrl")
   private val affinityGroupById: By  = By.id("affinityGroupSelect")
   private val authSubmitById: By     = By.id("submit-top")
+
+  private val enrolment: Enrolment        = TestConfiguration.enrolmentConfig.individual
+  private val enrolmentKeyById: By        = By.id("enrolment[0].name")
+  private val enrolmentIdentifierById: By = By.id("input-0-0-name")
+  private val enrolmentValueById: By      = By.id("input-0-0-value")
 
   def loadPage(): this.type = {
     navigateTo(pageUrl)
@@ -40,6 +45,9 @@ object AuthLoginPage extends BasePage {
   def loginAsBasic(): FiManagementFEDefaultPage.type = {
     loadPage()
     sendTextById(redirectionUrlById, redirectUrl)
+    sendTextById(enrolmentKeyById, enrolment.key)
+    sendTextById(enrolmentIdentifierById, enrolment.identifier)
+    sendTextById(enrolmentValueById, enrolment.value)
     clickOnById(authSubmitById)
     FiManagementFEDefaultPage
   }


### PR DESCRIPTION
Updated to the latest version of `ui-test-runner` which removes the need for running `docker-selenium-grid` in favour of the (included) Selenium Manager.

Added in Enrolment Config to allow tests to log into the service with a HMRC-FATCA-ORG enrolment